### PR TITLE
add a subscription type for the L2_25 order book subscription

### DIFF
--- a/Bitmex.NET/BitmetSocketSubscriptions.cs
+++ b/Bitmex.NET/BitmetSocketSubscriptions.cs
@@ -13,6 +13,11 @@ namespace Bitmex.NET
             return BitmexApiSubscriptionInfo<IEnumerable<InstrumentDto>>.Create(SubscriptionType.instrument, act);
         }
 
+        public static BitmexApiSubscriptionInfo<IEnumerable<OrderBookDto>> CreateOrderBookL225Subsription(Action<BitmexSocketDataMessage<IEnumerable<OrderBookDto>>> act)
+        {
+            return BitmexApiSubscriptionInfo<IEnumerable<OrderBookDto>>.Create(SubscriptionType.orderBookL2_25, act);
+        }
+
         public static BitmexApiSubscriptionInfo<IEnumerable<OrderBook10Dto>> CreateOrderBook10Subsription(Action<BitmexSocketDataMessage<IEnumerable<OrderBook10Dto>>> act)
         {
             return BitmexApiSubscriptionInfo<IEnumerable<OrderBook10Dto>>.Create(SubscriptionType.orderBook10, act);

--- a/Bitmex.NET/Models/Socket/SubscriptionType.cs
+++ b/Bitmex.NET/Models/Socket/SubscriptionType.cs
@@ -11,6 +11,7 @@
 		liquidation, // Liquidation orders as they're entered into the book
 		orderBookL2, // Full level 2 orderBook
 		orderBook10, // Top 10 levels using traditional full book push
+		orderBookL2_25, // throttled subset of the L2 order book
 		publicNotifications, // System-wide notifications (used for short-lived messages)
 		quote, // Top level of the book
 		quoteBin1m, // 1-minute quote bins


### PR DESCRIPTION
Add a new subscription type to use the L2_25 order book web socked feed.
The payload is the same as the L2 feed, so the OrderBookDto can be used.