### PR TITLE
Change QuoteDto AskPrice type from long? to decimal?

### DIFF
--- a/Bitmex.NET/Dtos/QuoteDto.cs
+++ b/Bitmex.NET/Dtos/QuoteDto.cs
@@ -13,13 +13,13 @@ namespace Bitmex.NET.Dtos
 		public string Symbol { get; set; }
 
 		[JsonProperty("bidSize")]
-		public decimal? BidSize { get; set; }
+		public long? BidSize { get; set; }
 
 		[JsonProperty("bidPrice")]
 		public decimal? BidPrice { get; set; }
 
 		[JsonProperty("askPrice")]
-		public long? AskPrice { get; set; }
+		public decimal? AskPrice { get; set; }
 
 		[JsonProperty("askSize")]
 		public long? AskSize { get; set; }


### PR DESCRIPTION
I was seeing the ask price rounded to whole numbers in my websocket responses.
The QuoteDto had "long?" as the type for "AskPrice".
I have changed this to "decimal?" and "BidSize" from decimal to long. 
This seems to have fixed the issue for me.