### PR TITLE
Remove DisplayQty from CreateSimpleLimit

### DIFF
--- a/Bitmex.NET/Models/Partials/OrderPOSTRequestParams.cs
+++ b/Bitmex.NET/Models/Partials/OrderPOSTRequestParams.cs
@@ -41,8 +41,24 @@ namespace Bitmex.NET.Models
                 Side = Enum.GetName(typeof(OrderSide), side),
                 OrderQty = quantity,
                 OrdType = Enum.GetName(typeof(OrderType), OrderType.Limit),
-                DisplayQty = quantity,
                 Price = price,
+                // only iceberg order must have the displayQty declared
+                // DisplayQty = displayQty,
+                ExecInst = "ParticipateDoNotInitiate",
+            };
+        }
+
+        public static OrderPOSTRequestParams CreateSimpleLimitIceberg(string symbol, decimal quantity, decimal displayQty, decimal price, OrderSide side)
+        {
+            return new OrderPOSTRequestParams
+            {
+                Symbol = symbol,
+                Side = Enum.GetName(typeof(OrderSide), side),
+                OrderQty = quantity,
+                OrdType = Enum.GetName(typeof(OrderType), OrderType.Limit),
+                Price = price,
+                // only iceberg order must have the displayQty declared
+                DisplayQty = displayQty,
                 ExecInst = "ParticipateDoNotInitiate",
             };
         }


### PR DESCRIPTION
I created a new method CreateSimpleLimitIceberg in order to create a new order with a defined displayed quantity.
I remove the field displayQty from the object used in the method CreateSimpleLimit.
I think it is correct to not send the field displayQty when we want to create a simple limit order, because if you try to amend an order with a defined displayQty it becomes an Iceberg order.